### PR TITLE
Add synth

### DIFF
--- a/sox/__init__.py
+++ b/sox/__init__.py
@@ -20,7 +20,7 @@ stream_handler.close()
 
 from . import file_info
 from .combine import Combiner
-from .transform import Transformer
+from .transform import Transformer, SynthTransformer
 from .core import SoxError
 from .core import SoxiError
 from .version import version as __version__

--- a/sox/transform.py
+++ b/sox/transform.py
@@ -3372,7 +3372,9 @@ class Transformer(object):
         return self
 
     def trim(self, start_time, end_time=None):
-        '''Excerpt a clip from an audio file, given the start timestamp and end timestamp of the clip within the file, expressed in seconds. If the end timestamp is set to `None` or left unspecified, it defaults to the duration of the audio file.
+        '''Excerpt a clip from an audio file, given the start timestamp and end timestamp of the
+        clip within the file, expressed in seconds. If the end timestamp is set to `None` or left
+        unspecified, it defaults to the duration of the audio file.
 
         Parameters
         ----------

--- a/tests/test_synth_transform.py
+++ b/tests/test_synth_transform.py
@@ -1,0 +1,117 @@
+import numpy as np
+import soundfile as sf
+import tempfile
+import unittest
+
+from sox import transform
+
+
+class TestSynthTransformerDefault(unittest.TestCase):
+
+    def setUp(self):
+        self.tfm = transform.SynthTransformer()
+
+    def test_globals(self):
+        expected = ['-D', '-V2']
+        actual = self.tfm.globals
+        self.assertEqual(expected, actual)
+
+    def test_input_format(self):
+        expected = {'channels': 1}
+        actual = self.tfm.input_format
+        self.assertEqual(expected, actual)
+
+    def test_output_format(self):
+        expected = {}
+        actual = self.tfm.output_format
+        self.assertEqual(expected, actual)
+
+    def test_effects(self):
+        expected = ['synth']
+        actual = self.tfm.effects
+        self.assertEqual(expected, actual)
+
+    def test_effects_log(self):
+        expected = []
+        actual = self.tfm.effects_log
+        self.assertEqual(expected, actual)
+
+    def test_invalid_build_args(self):
+        with self.assertRaises(ValueError):
+            self.tfm.build_array(input_filepath='some_path')
+
+        with self.assertRaises(ValueError):
+            sig = np.zeros(16000)
+            self.tfm.build_array(input_array=sig)
+
+
+class TestSynthTransformerInvalidMethods(unittest.TestCase):
+
+    def setUp(self):
+        self.tfm = transform.SynthTransformer()
+
+    def test_set_input_format(self):
+        with self.assertRaises(AttributeError):
+            self.tfm.set_input_format(file_type='wav')
+
+
+class TestSynthTransformerNoise(unittest.TestCase):
+
+    def setUp(self):
+        self.tfm = transform.SynthTransformer()
+
+    def test_invalid_noise_type(self):
+        with self.assertRaises(ValueError):
+            self.tfm._add_noise('invalid-noise-type', 3)
+
+    def test_invalid_times(self):
+        noise_type = self.tfm._valid_noise_types[0]
+        with self.assertRaises(ValueError):
+            self.tfm._add_noise(noise_type, -1)
+
+        with self.assertRaises(ValueError):
+            self.tfm._add_noise(noise_type, 0)
+
+    def test_build_array(self):
+        sr = 16000
+        dur = 3
+        self.tfm.whitenoise(length=dur)
+        got = self.tfm.build_array(sample_rate_in=sr)
+        expected = sr * dur
+        self.assertEqual(expected, got.size)
+
+    def test_build_file(self):
+        sr = 16000
+        dur = 3
+        with tempfile.NamedTemporaryFile(suffix='.wav') as f:
+            self.tfm.whitenoise(length=dur)
+            self.tfm.build_file(output_filepath=f.name, sample_rate_in=sr)
+            got, got_sr = sf.read(f.name)
+
+            expected = sr * dur
+            self.assertEqual(expected, got.size)
+            self.assertEqual(sr, got_sr)
+
+    def test_pinknoise(self):
+        sr = 16000
+        dur = 3
+        self.tfm.pinknoise(length=dur)
+        got = self.tfm.build_array(sample_rate_in=sr)
+        expected = sr * dur
+        self.assertEqual(expected, got.size)
+
+    def test_brownnoise(self):
+        sr = 16000
+        dur = 3
+        self.tfm.brownnoise(length=dur)
+        got = self.tfm.build_array(sample_rate_in=sr)
+        expected = sr * dur
+        self.assertEqual(expected, got.size)
+
+    def test_tpdfnoise(self):
+        sr = 16000
+        dur = 3
+        self.tfm.tpdfnoise(length=dur)
+        got = self.tfm.build_array(sample_rate_in=sr)
+        expected = sr * dur
+        self.assertEqual(expected, got.size)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 
-from sox import transform, file_info
+from sox import transform
 from sox.core import SoxError
 import soundfile as sf
 import numpy as np
@@ -665,6 +665,7 @@ class TestTransformSetOutputFormat(unittest.TestCase):
             self.tfm.set_output_format(append_comments=None)
         with self.assertRaises(ValueError):
             self.tfm._output_format_args({'append_comments': None})
+
 
 class TestTransformerBuild(unittest.TestCase):
     def setUp(self):
@@ -1702,7 +1703,7 @@ class TestTransformerConvert(unittest.TestCase):
         expected_res = True
         self.assertEqual(expected_res, actual_res)
 
-        ## pysndfile doesn't support int8
+        # pysndfile doesn't support int8
         # tfm.set_output_format(file_type='raw', bits=8)
         # tfm_assert_array_to_file_output(
         #     INPUT_FILE, OUTPUT_FILE, tfm, dtype_out='int8', test_file_out=False)
@@ -3100,8 +3101,8 @@ class TestTransformerMcompand(unittest.TestCase):
             decay_time=[0.020, 0.020, 0.020],
             soft_knee_db=[None, 2.0, None],
             tf_points=[[(-40, -40), (0, 0)],
-                [(-40, -40), (-30, -38), (-20, -36), (0, -34)],
-                [(-40, -40), (0, 0)]],
+                       [(-40, -40), (-30, -38), (-20, -36), (0, -34)],
+                       [(-40, -40), (0, 0)]],
             gain=[None, None, None])
         actual_args = tfm.effects
         expected_args = [


### PR DESCRIPTION
Adds `SynthTransformer` subclass of `Transformer`, which is used to call Sox's `synth` mode.
Currently only adds noise synth types: `whitenoise`, `pinknoise`, `brownnoise`, and `tpdfnoise`.
Adds some simple tests.